### PR TITLE
[+] Allow mock to work with `Request` type argument

### DIFF
--- a/mock-fetch-api.js
+++ b/mock-fetch-api.js
@@ -33,6 +33,15 @@ global.fetch = function(uri, options) {
       headers: null,
    }, options || {});
 
+   if (uri instanceof Request) {
+        options = uri;
+        uri = uri.url;
+
+        if (!options.method) {
+            options.method = 'GET'
+        }
+    }
+   
    return new Promise(function(resolve, reject) {
 
       if(failNextCall) {


### PR DESCRIPTION
You can call fetch with `fetch(url, options)` or with `fetch(new Request(url, options))`